### PR TITLE
Java Backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       kompose.service.type: nodeport # Adds a label for Kompose to expose service externally
 
   backend: # KillrVideo Backend 
-    image: killrvideo/killrvideo-nodejs:3.0.0-rc2
+    image: killrvideo/killrvideo-java:3.0.0-alpha2
     ports:
       - "50101:50101" # Exposes port to be available. Kompose tool needs that to create a k8s service and make backend available for other services.
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,9 +47,7 @@ services:
       memlock: -1
 
   dse-config: # One-Time Bootstrap Container, configures DSE to have required keyspaces etc.
-    image: killrvideo/killrvideo-dse-config:2.2.2-rc2
-    environment:
-      KILLRVIDEO_SERVICE_DISCOVERY_DISABLED: 'true' # Backward Compatibility Requirement
+    image: killrvideo/killrvideo-dse-config:3.0.0-rc1
     depends_on:
       - dse # Needs DSE to be running
     restart: on-failure # Kompose needs that to create dse-config as a pod, not a deployment. DSE-Config deployment is not needed as we run it only once.

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       - env:
         - name: KILLRVIDEO_LOGGING_LEVEL
           value: debug
-        image: killrvideo/killrvideo-nodejs:3.0.0-rc2
+        image: killrvideo/killrvideo-java:3.0.0-alpha2
         name: backend
         ports:
         - containerPort: 50101

--- a/k8s/dse-config-pod.yaml
+++ b/k8s/dse-config-pod.yaml
@@ -7,10 +7,7 @@ metadata:
   name: dse-config
 spec:
   containers:
-  - env:
-    - name: KILLRVIDEO_SERVICE_DISCOVERY_DISABLED
-      value: "true"
-    image: killrvideo/killrvideo-dse-config:2.2.2-rc2
+  - image: killrvideo/killrvideo-dse-config:3.0.0-rc1
     name: dse-config
     resources: {}
   restartPolicy: OnFailure


### PR DESCRIPTION
- Switches backend from NodeJS to Java version which is probably more often used by developers and adds recommendation engine (was not available before)
- Updates k8s definitions (were outdated for dse-config)